### PR TITLE
gutenberg awb_image: update default value to correct type

### DIFF
--- a/src/assets/admin/gutenberg/block.js
+++ b/src/assets/admin/gutenberg/block.js
@@ -1273,7 +1273,7 @@ export const settings = {
 
         image: {
             type: 'number',
-            default: '',
+            default: 0,
         },
         imageTag: {
             type: 'string',


### PR DESCRIPTION
I'm using ghostkit&awb with [wp-graphql-gutenberg](https://github.com/pristas-peter/wp-graphql-gutenberg) for quering blocks for gatbyjs. I found there a small type bug causing return block's attributes array as null. 