### PR TITLE
chore(git): collapse vendored code in diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,3 +11,6 @@
 *.svg   text eol=lf
 *.txt   text eol=lf
 *.yml   text eol=lf
+
+# Third-party code, excluded from the language statistics.
+src/vendors/**  linguist-vendored=true


### PR DESCRIPTION
## Why

This repository builds into `dist/`, which is git-ignored, so there is no
generated output to hide. What it does commit is third-party code, and that
shows up in pull request diffs and in the repository language statistics,
where it is only noise. The minified vendor assets render as unreadable blobs
for the same reason built files do — they are single very long lines.

## What changed

`.gitattributes` now marks the vendored paths:

- **`linguist-vendored=true`** — GitHub hides these files by default in pull
  request diffs (collapsed behind *Load diff*) and drops them from the
  repository language statistics.
- **`-diff`** on the minified vendor assets — git prints
  `Binary files ... differ` locally instead of the blob. This affects diff
  rendering only; merges are unaffected, since the merge driver is a separate
  attribute.

## What does not change

Nothing in the build, the release packaging, or CI. `.gitattributes` only
affects how diffs are rendered and how GitHub counts languages. Every file
stays tracked exactly as before.

## Verification

`git check-attr diff linguist-vendored` was run against real tracked paths in
this repository: the patterns match the vendored files, and every first-party
source file resolves to `unspecified`.

---

Part of a pass across the plugin repositories. Sibling repositories that commit
their build output get the same treatment for `build/`.
